### PR TITLE
Fixed broken artifact link.

### DIFF
--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
@@ -55,7 +55,7 @@ public class WebhookPublisher extends Notifier {
 
         for (Object a : build.getArtifacts()) {
             Run.Artifact artifact = (Run.Artifact) a;
-            artifacts.append(" - ").append(globalConfig.getUrl()).append(artifact.getHref()).append("\n");
+            artifacts.append(" - ").append(globalConfig.getUrl()).append(build.getUrl()).append("artifact/").append(artifact.getHref()).append("\n");
         }
 
         boolean buildStatus = build.getResult().isBetterOrEqualTo(Result.SUCCESS);


### PR DESCRIPTION
This PR fixes broken artifact links, since some parts of the URL were missing.

Previous (broken) artifacts link:
http://${pathToJenkins}/${pathToArtifact}

New (fixed) artifacts link:
http://${pathToJenkins}/job/${jobName}/${buildNumber}/artifact/${pathToArtifact}
or (more general):
http://${pathToJenkins}/${pathToBuild}/artifact/${pathToArtifact}

(Edit: Fixed wrong URL formatting)