### PR TITLE
fix issue with "send on state change"

### DIFF
--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
@@ -59,7 +59,7 @@ public class WebhookPublisher extends Notifier {
         }
 
         if (this.sendOnStateChange) {
-            if (!build.getResult().equals(build.getPreviousBuild().getResult())) {
+            if (build.getResult().equals(build.getPreviousBuild().getResult())) {
                 // Stops the webhook payload being created if the status is the same as the previous
                 return true;
             }


### PR DESCRIPTION
See #8. The existing code exits out if the current build is not equal to the previous... it should do the exact opposite and exit out only if they're equal.