### PR TITLE
embed the build url in the build id and status within the description

### DIFF
--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
@@ -71,15 +71,10 @@ public class WebhookPublisher extends Notifier {
         wh.setTitle(build.getProject().getDisplayName() + " #" + build.getId());
 
         String url = globalConfig.getUrl() + build.getUrl();
-        String descriptionPrefix = "**Build:** [#"
-                + build.getId()
-                + "]("
-                + url
-                + ")\n**Status:** ["
-                + build.getResult().toString().toLowerCase()
-                + "]("
-                + url
-                + ")";
+        String descriptionPrefix = "**Build:** "
+                + getMarkdownHyperlink(build.getID(), url)
+                + "\n**Status:** "
+                + getMarkdownHyperlink(build.getResult().toString().toLowerCase(), url);
 
         wh.setDescription(new EmbedDescription(build, globalConfig, descriptionPrefix, this.enableArtifactList).toString());
         wh.setStatus(buildStatus);
@@ -112,5 +107,9 @@ public class WebhookPublisher extends Notifier {
         public String getDisplayName() { return NAME; }
 
         public String getVersion() { return VERSION; }
+    }
+    
+    private String getMarkdownHyperlink(String content, String url) {
+        return "[" + content + "](" + url + ")";
     }
 }

--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
@@ -70,7 +70,16 @@ public class WebhookPublisher extends Notifier {
         DiscordWebhook wh = new DiscordWebhook(this.webhookURL);
         wh.setTitle(build.getProject().getDisplayName() + " #" + build.getId());
 
-        String descriptionPrefix = "**Build:**  #" + build.getId() + "\n**Status:**  " + (build.getResult().toString().toLowerCase());
+        String url = globalConfig.getUrl() + build.getUrl();
+        String descriptionPrefix = "**Build:** [#"
+                + build.getId()
+                + "]("
+                + url
+                + ")\n**Status:** ["
+                + build.getResult().toString().toLowerCase()
+                + "]("
+                + url
+                + ")";
 
         wh.setDescription(new EmbedDescription(build, globalConfig, descriptionPrefix, this.enableArtifactList).toString());
         wh.setStatus(buildStatus);


### PR DESCRIPTION
#11: This PR makes both the build id and the status message a link back to the build.