### PR TITLE
Update env variable in pipeline build example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ pipeline {
 
   post {
     always {
-      discordSend description: 'Jenkins Pipeline Build', footer: 'Footer Text', link: BUILD_URL, successful: currentBuild.resultIsBetterOrEqualTo('SUCCESS'), title: JOB_NAME, webhookURL: 'Webhook URL'
+      discordSend description: 'Jenkins Pipeline Build', footer: 'Footer Text', link: env.BUILD_URL, successful: currentBuild.resultIsBetterOrEqualTo('SUCCESS'), title: JOB_NAME, webhookURL: 'Webhook URL'
     }
   }
 }


### PR DESCRIPTION
Update the link variable to `env.BUILD_URL` as using the example as is causes Jenkins to throw the following build error: `groovy.lang.MissingPropertyException: No such property: BUILD_URL for class: WorkflowScript`

This is reproducible using:
* `Jenkins ver. 2.107.3`
* `Pipeline 2.5`