### PR TITLE
Add support for canary/ptb webhooks

### DIFF
--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
@@ -146,7 +146,7 @@ public class WebhookPublisher extends Notifier {
         public boolean isApplicable(Class<? extends AbstractProject> aClass) { return true; }
 
         public FormValidation doCheckWebhookURL(@QueryParameter String value) {
-            if (!value.matches("https://discordapp\\.com/api/webhooks/\\d{18}/(\\w|-|_)*(/?)"))
+            if (!value.matches("https://(canary.|ptb.|)discordapp\\.com/api/webhooks/\\d{18}/(\\w|-|_)*(/?)"))
                 return FormValidation.error("Please enter a valid Discord webhook URL.");
             return FormValidation.ok();
         }


### PR DESCRIPTION
When you login through a canary client (or the site) and generate a Webhook, you get something like `https://canary.discordapp.com/api/webhooks/<channel snowflake>/<stuff>`.

You get a similar result on ptb client too, just with `ptb.` instead of `canary.`.

While throwing `canary.` or `ptb.` from domain doesn't affect its functionality (it works the same), I prefer to keep webhooks on the domain I get them from as they still work, and this causes Jenkins to nag me and throw a error even though it works perfectly fine when I save it and try it out.

This PR adds support for ptb and canary webhooks to finally end the nag.