### PR TITLE
Properly escape dot on webhook URL verification regex

### DIFF
--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
@@ -146,7 +146,7 @@ public class WebhookPublisher extends Notifier {
         public boolean isApplicable(Class<? extends AbstractProject> aClass) { return true; }
 
         public FormValidation doCheckWebhookURL(@QueryParameter String value) {
-            if (!value.matches("https://(canary\.|ptb\.|)discordapp\\.com/api/webhooks/\\d{18}/(\\w|-|_)*(/?)"))
+            if (!value.matches("https://(canary\\.|ptb\\.|)discordapp\\.com/api/webhooks/\\d{18}/(\\w|-|_)*(/?)"))
                 return FormValidation.error("Please enter a valid Discord webhook URL.");
             return FormValidation.ok();
         }

--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
@@ -146,7 +146,7 @@ public class WebhookPublisher extends Notifier {
         public boolean isApplicable(Class<? extends AbstractProject> aClass) { return true; }
 
         public FormValidation doCheckWebhookURL(@QueryParameter String value) {
-            if (!value.matches("https://(canary.|ptb.|)discordapp\\.com/api/webhooks/\\d{18}/(\\w|-|_)*(/?)"))
+            if (!value.matches("https://(canary\.|ptb\.|)discordapp\\.com/api/webhooks/\\d{18}/(\\w|-|_)*(/?)"))
                 return FormValidation.error("Please enter a valid Discord webhook URL.");
             return FormValidation.ok();
         }


### PR DESCRIPTION
Whoops, a friend just noticed that I forgot to escape the dots.

It'll function properly in the current version, but escaping them makes the checks more accurate.